### PR TITLE
fix: added rust-toolchain for reproducible builds

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2021-12-14"
+components = [ "rustfmt", "rust-std", "clippy" ]
+targets = [ "x86_64-unknown-linux-gnu" ]


### PR DESCRIPTION
Hello!
A friend tried to build your repo, but couldn't, due to wrong cargo/rustc version. So I just pinned down a nightly version that seems to work and pinned it in a `rust-toolchain.toml` file that cargo should pick up automatically.

Builds should be easier with this :)

I hope it helps